### PR TITLE
Bca/fix dm not e2e bydefault

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/CryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/CryptoService.kt
@@ -119,7 +119,7 @@ interface CryptoService {
 
     fun shouldEncryptForInvitedMembers(roomId: String): Boolean
 
-    fun downloadKeys(userIds: List<String>, forceDownload: Boolean, callback: MatrixCallback<MXUsersDevicesMap<CryptoDeviceInfo>>)
+    suspend fun downloadKeys(userIds: List<String>, forceDownload: Boolean = false): MXUsersDevicesMap<CryptoDeviceInfo>
 
     fun getCryptoDeviceInfo(userId: String): List<CryptoDeviceInfo>
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
@@ -164,7 +164,7 @@ internal class DefaultCryptoService @Inject constructor(
             EventType.STATE_ROOM_MEMBER             -> onRoomMembershipEvent(roomId, event)
             EventType.STATE_ROOM_HISTORY_VISIBILITY -> onRoomHistoryVisibilityEvent(roomId, event)
             else                                    -> cryptoCoroutineScope.launch {
-                this@DefaultCryptoService.verificationService?.onEvent(event)
+                this@DefaultCryptoService.verificationService.onEvent(event)
             }
         }
     }
@@ -701,7 +701,7 @@ internal class DefaultCryptoService @Inject constructor(
                         // The rust-sdk will clear this event if it's invalid, this will produce an invalid base64 error
                         // when we try to construct the recovery key.
                         val secretContent = event.getClearContent().toModel<SecretSendEventContent>() ?: return@forEach
-                        this.keysBackupService?.onSecretKeyGossip(secretContent.secretValue)
+                        this.keysBackupService.onSecretKeyGossip(secretContent.secretValue)
                     }
                     else                         -> {
                         this.verificationService.onEvent(event)
@@ -753,7 +753,7 @@ internal class DefaultCryptoService @Inject constructor(
         // If we sent out a room key over to-device messages it's likely that we created a new one
         // Try to back the key up
         if (sharedKey) {
-            keysBackupService?.maybeBackupKeys()
+            keysBackupService.maybeBackupKeys()
         }
     }
 
@@ -868,8 +868,8 @@ internal class DefaultCryptoService @Inject constructor(
     override suspend fun importRoomKeys(roomKeysAsArray: ByteArray,
                                         password: String,
                                         progressListener: ProgressListener?): ImportRoomKeysResult {
-        val result = olmMachine!!.importKeys(roomKeysAsArray, password, progressListener)
-        keysBackupService?.maybeBackupKeys()
+        val result = olmMachine.importKeys(roomKeysAsArray, password, progressListener)
+        keysBackupService.maybeBackupKeys()
 
         return result
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
@@ -1008,13 +1008,7 @@ internal class DefaultCryptoService @Inject constructor(
     override fun downloadKeys(userIds: List<String>, forceDownload: Boolean, callback: MatrixCallback<MXUsersDevicesMap<CryptoDeviceInfo>>) {
         cryptoCoroutineScope.launch(coroutineDispatchers.crypto) {
             runCatching {
-                if (forceDownload) {
-                    // TODO replicate the logic from the device list manager
-                    // where we would download the fresh info from the server.
-                    this@DefaultCryptoService.olmMachine.getUserDevicesMap(userIds) // ?: MXUsersDevicesMap()
-                } else {
-                    this@DefaultCryptoService.olmMachine.getUserDevicesMap(userIds) // ?: MXUsersDevicesMap()
-                }
+                olmMachine.ensureUserDevicesMap(userIds, forceDownload)
             }.foldToCallback(callback)
         }
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OlmMachine.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OlmMachine.kt
@@ -311,7 +311,7 @@ internal class OlmMachine(
                     DeviceLists(deviceChanges?.changed.orEmpty(), deviceChanges?.left.orEmpty())
             val adapter =
                     MoshiProvider.providesMoshi().adapter(ToDeviceSyncResponse::class.java)
-            val events = toDevice?.let { adapter.toJson(it) } ?: "[]"
+            val events = adapter.toJson(toDevice ?: ToDeviceSyncResponse())!!
 
             adapter.fromJson(inner.receiveSyncChanges(events, devices, counts)) ?: ToDeviceSyncResponse()
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/create/CreateRoomBodyBuilder.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/create/CreateRoomBodyBuilder.kt
@@ -181,7 +181,7 @@ internal class CreateRoomBodyBuilder @Inject constructor(
                 params.invite3pids.isEmpty() &&
                 params.invitedUserIds.isNotEmpty() &&
                 params.invitedUserIds.let { userIds ->
-            val keys =  olmMachineProvider.olmMachine.getUserDevicesMap(userIds)
+            val keys =  olmMachineProvider.olmMachine.ensureUserDevicesMap(userIds, forceDownload = false)
             // deviceListManager.downloadKeys(userIds, forceDownload = false)
 
             userIds.all { userId ->

--- a/rust-sdk/Makefile
+++ b/rust-sdk/Makefile
@@ -1,3 +1,5 @@
+all: x86 aarch64 armv7-linux-androideabi
+
 # x86_64:
 # 	cargo build --release --target x86_64-linux-android
 # 	mkdir -p ../matrix-sdk-android/src/main/jniLibs/x86_64/

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
@@ -47,8 +47,6 @@ import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.api.session.room.roomSummaryQueryParams
 import org.matrix.android.sdk.api.util.toMatrixItem
 import org.matrix.android.sdk.flow.flow
-import org.matrix.android.sdk.internal.crypto.model.CryptoDeviceInfo
-import org.matrix.android.sdk.internal.crypto.model.MXUsersDevicesMap
 import org.matrix.android.sdk.internal.util.awaitCallback
 import timber.log.Timber
 import kotlin.coroutines.Continuation
@@ -181,9 +179,7 @@ class HomeActivityViewModel @AssistedInject constructor(
             val session = activeSessionHolder.getSafeActiveSession() ?: return@launch
 
             tryOrNull("## MaybeBootstrapCrossSigning: Failed to download keys") {
-                awaitCallback<MXUsersDevicesMap<CryptoDeviceInfo>> {
-                    session.cryptoService().downloadKeys(listOf(session.myUserId), true, it)
-                }
+                session.cryptoService().downloadKeys(listOf(session.myUserId), true)
             }
 
             // From there we are up to date with server

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewModel.kt
@@ -169,7 +169,7 @@ class DevicesViewModel @AssistedInject constructor(
         refreshSource.stream().throttleFirst(4_000)
                 .onEach {
                     session.cryptoService().fetchDevicesList(NoOpMatrixCallback())
-                    session.cryptoService().downloadKeys(listOf(session.myUserId), true, NoOpMatrixCallback())
+                    session.cryptoService().downloadKeys(listOf(session.myUserId), true)
                 }
                 .launchIn(viewModelScope)
         // then force download


### PR DESCRIPTION
When creating a DM with a user never seen before it was not e2e by default.

Added back some logic from DeviceListManager that would download keys if needed.
As I don't have API to know if the rust sdk is tracking a user (and has keys i.e. not pending), I consider that it's the case if his list of known devices is empty (but it may query too much)

=> Added `ensureUserDevicesMap(userIds: List<String>, forceDownload: Boolean = false)` in olmMachine