### PR TITLE
Feature/fga/backup recovery key

### DIFF
--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/common/CryptoTestHelper.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/common/CryptoTestHelper.kt
@@ -38,6 +38,7 @@ import org.matrix.android.sdk.api.session.crypto.crosssigning.KEYBACKUP_SECRET_S
 import org.matrix.android.sdk.api.session.crypto.crosssigning.MASTER_KEY_SSSS_NAME
 import org.matrix.android.sdk.api.session.crypto.crosssigning.SELF_SIGNING_KEY_SSSS_NAME
 import org.matrix.android.sdk.api.session.crypto.crosssigning.USER_SIGNING_KEY_SSSS_NAME
+import org.matrix.android.sdk.api.session.crypto.keysbackup.BackupRecoveryKey
 import org.matrix.android.sdk.api.session.crypto.keysbackup.MegolmBackupAuthData
 import org.matrix.android.sdk.api.session.crypto.keysbackup.MegolmBackupCreationInfo
 import org.matrix.android.sdk.api.session.crypto.keysbackup.extractCurveKeyFromRecoveryKey
@@ -250,7 +251,7 @@ class CryptoTestHelper(private val testHelper: CommonTestHelper) {
         return MegolmBackupCreationInfo(
                 algorithm = MXCRYPTO_ALGORITHM_MEGOLM_BACKUP,
                 authData = createFakeMegolmBackupAuthData(),
-                recoveryKey = "fake"
+                recoveryKey = BackupRecoveryKey.fromBase58("3cnTdW")
         )
     }
 
@@ -445,7 +446,7 @@ class CryptoTestHelper(private val testHelper: CommonTestHelper) {
             // Save it for gossiping
             session.cryptoService().keysBackupService().saveBackupRecoveryKey(creationInfo.recoveryKey, version = version.version)
 
-            extractCurveKeyFromRecoveryKey(creationInfo.recoveryKey)?.toBase64NoPadding()?.let { secret ->
+            extractCurveKeyFromRecoveryKey(creationInfo.recoveryKey.toBase58())?.toBase64NoPadding()?.let { secret ->
                 ssssService.storeSecret(
                         KEYBACKUP_SECRET_SSSS_NAME,
                         secret,

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/E2eeSanityTests.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/E2eeSanityTests.kt
@@ -640,6 +640,7 @@ class E2eeSanityTests : InstrumentedTest {
                         // for the test we just accept?
                         oldCode = sasTx.getDecimalCodeRepresentation()
                         testHelper.runBlockingTest {
+                            delay(500)
                             sasTx.userHasVerifiedShortCode()
                         }
                     }
@@ -666,11 +667,12 @@ class E2eeSanityTests : InstrumentedTest {
                 val sasTx = tx as SasVerificationTransaction
                 when (sasTx.state) {
                     VerificationTxState.ShortCodeReady -> {
+                        newCode = sasTx.getDecimalCodeRepresentation()
                         if (matchOnce) {
                             testHelper.runBlockingTest {
+                                delay(500)
                                 sasTx.userHasVerifiedShortCode()
                             }
-                            newCode = sasTx.getDecimalCodeRepresentation()
                             matchOnce = false
                         }
                     }
@@ -712,6 +714,7 @@ class E2eeSanityTests : InstrumentedTest {
                 aliceNewSession.cryptoService().keysBackupService().getKeyBackupRecoveryKeyInfo() != null
             }
         }
+
         testHelper.runBlockingTest {
             assertEquals(
                     "MSK Private parts should be the same",

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/keysbackup/KeysBackupTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/keysbackup/KeysBackupTest.kt
@@ -34,6 +34,7 @@ import org.junit.runners.MethodSorters
 import org.matrix.android.sdk.InstrumentedTest
 import org.matrix.android.sdk.api.crypto.MXCRYPTO_ALGORITHM_MEGOLM_BACKUP
 import org.matrix.android.sdk.api.listeners.StepProgressListener
+import org.matrix.android.sdk.api.session.crypto.keysbackup.BackupRecoveryKey
 import org.matrix.android.sdk.api.session.crypto.keysbackup.KeysBackupState
 import org.matrix.android.sdk.api.session.crypto.keysbackup.KeysBackupStateListener
 import org.matrix.android.sdk.api.session.crypto.keysbackup.toKeysVersionResult
@@ -505,7 +506,7 @@ class KeysBackupTest : InstrumentedTest {
             try {
                 testData.aliceSession2.cryptoService().keysBackupService().trustKeysBackupVersionWithRecoveryKey(
                         testData.aliceSession2.cryptoService().keysBackupService().keysBackupVersion!!,
-                        "Bad recovery key"
+                        BackupRecoveryKey.fromBase58("Bad recovery key")
                 )
                 fail("Should have failed to trust")
             } catch (failure: Throwable) {
@@ -645,7 +646,7 @@ class KeysBackupTest : InstrumentedTest {
         var importRoomKeysResult: ImportRoomKeysResult? = null
         testHelper.runBlockingTest {
             testData.aliceSession2.cryptoService().keysBackupService().restoreKeysWithRecoveryKey(testData.aliceSession2.cryptoService().keysBackupService().keysBackupVersion!!,
-                    "EsTc LW2K PGiF wKEA 3As5 g5c4 BXwk qeeJ ZJV8 Q9fu gUMN UE4d",
+                    BackupRecoveryKey.fromBase58("EsTc LW2K PGiF wKEA 3As5 g5c4 BXwk qeeJ ZJV8 Q9fu gUMN UE4d"),
                     null,
                     null,
                     null

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/keysbackup/BackupRecoveryKey.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/keysbackup/BackupRecoveryKey.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.api.session.crypto.keysbackup
+
+import uniffi.olm.BackupRecoveryKey as InnerBackupRecoveryKey
+
+class BackupRecoveryKey internal constructor(internal val inner: InnerBackupRecoveryKey) {
+
+    constructor() : this(InnerBackupRecoveryKey())
+
+    companion object {
+
+        fun fromBase58(key: String): BackupRecoveryKey {
+            val inner = InnerBackupRecoveryKey.fromBase58(key)
+            return BackupRecoveryKey(inner)
+        }
+
+        fun fromBase64(key: String): BackupRecoveryKey {
+            val inner = InnerBackupRecoveryKey.fromBase64(key)
+            return BackupRecoveryKey(inner)
+        }
+
+        fun fromPassphrase(passphrase: String, salt: String, rounds: Int): BackupRecoveryKey {
+            val inner = InnerBackupRecoveryKey.fromPassphrase(passphrase, salt, rounds)
+            return BackupRecoveryKey(inner)
+        }
+
+        fun newFromPassphrase(passphrase: String): BackupRecoveryKey {
+            val inner = InnerBackupRecoveryKey.newFromPassphrase(passphrase)
+            return BackupRecoveryKey(inner)
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is BackupRecoveryKey) return false
+        return this.toBase58() == other.toBase58()
+    }
+
+    fun toBase58() = inner.toBase58()
+
+    fun toBase64() = inner.toBase64()
+
+    fun decryptV1(ephemeralKey: String, mac: String, ciphertext: String) = inner.decryptV1(ephemeralKey, mac, ciphertext)
+
+    fun megolmV1PublicKey() = inner.megolmV1PublicKey()
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/keysbackup/KeysBackupService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/keysbackup/KeysBackupService.kt
@@ -142,8 +142,7 @@ interface KeysBackupService {
      * @param keysBackupVersion the backup version to check.
      * @param recoveryKey the recovery key to challenge with the key backup public key.
      */
-    suspend fun trustKeysBackupVersionWithRecoveryKey(keysBackupVersion: KeysVersionResult,
-                                              recoveryKey: String)
+    suspend fun trustKeysBackupVersionWithRecoveryKey(keysBackupVersion: KeysVersionResult, recoveryKey: BackupRecoveryKey)
 
     /**
      * Set trust on a keys backup version.
@@ -167,7 +166,7 @@ interface KeysBackupService {
      * @param callback             Callback. It provides the number of found keys and the number of successfully imported keys.
      */
     suspend fun restoreKeysWithRecoveryKey(keysVersionResult: KeysVersionResult,
-                                   recoveryKey: String, roomId: String?,
+                                   recoveryKey: BackupRecoveryKey, roomId: String?,
                                    sessionId: String?,
                                    stepProgressListener: StepProgressListener?): ImportRoomKeysResult
 
@@ -194,10 +193,10 @@ interface KeysBackupService {
     val state: KeysBackupState
 
     // For gossiping
-    fun saveBackupRecoveryKey(recoveryKey: String?, version: String?)
+    fun saveBackupRecoveryKey(recoveryKey: BackupRecoveryKey?, version: String?)
     suspend fun getKeyBackupRecoveryKeyInfo(): SavedKeyBackupKeyInfo?
 
-    suspend fun isValidRecoveryKeyForCurrentVersion(recoveryKey: String): Boolean
+    suspend fun isValidRecoveryKeyForCurrentVersion(recoveryKey: BackupRecoveryKey): Boolean
 
     fun computePrivateKey(passphrase: String,
                           privateKeySalt: String,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/keysbackup/MegolmBackupCreationInfo.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/keysbackup/MegolmBackupCreationInfo.kt
@@ -31,7 +31,7 @@ data class MegolmBackupCreationInfo(
         val authData: MegolmBackupAuthData,
 
         /**
-         * The Base58 recovery key.
+         * The recovery key.
          */
-        val recoveryKey: String
+        val recoveryKey: BackupRecoveryKey
 )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/keysbackup/SavedKeyBackupKeyInfo.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/keysbackup/SavedKeyBackupKeyInfo.kt
@@ -17,6 +17,6 @@
 package org.matrix.android.sdk.api.session.crypto.keysbackup
 
 data class SavedKeyBackupKeyInfo(
-        val recoveryKey: String,
+        val recoveryKey: BackupRecoveryKey,
         val version: String
 )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
@@ -65,7 +65,7 @@ import org.matrix.android.sdk.api.session.sync.model.DeviceListResponse
 import org.matrix.android.sdk.api.session.sync.model.DeviceOneTimeKeysCountSyncResponse
 import org.matrix.android.sdk.api.session.sync.model.ToDeviceSyncResponse
 import org.matrix.android.sdk.internal.crypto.keysbackup.RustKeyBackupService
-import org.matrix.android.sdk.internal.crypto.network.NetworkRequestsProcessor
+import org.matrix.android.sdk.internal.crypto.network.OutgoingRequestsProcessor
 import org.matrix.android.sdk.internal.crypto.network.RequestSender
 import org.matrix.android.sdk.internal.crypto.repository.WarnOnUnknownDeviceRepository
 import org.matrix.android.sdk.internal.crypto.store.IMXCryptoStore
@@ -131,7 +131,7 @@ internal class DefaultCryptoService @Inject constructor(
 
     private val olmMachine by lazy { olmMachineProvider.olmMachine }
 
-    private val outgoingRequestsProcessor = NetworkRequestsProcessor(
+    private val outgoingRequestsProcessor = OutgoingRequestsProcessor(
             requestSender = requestSender,
             coroutineScope = cryptoCoroutineScope,
             cryptoSessionInfoProvider = cryptoSessionInfoProvider,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/PerSessionBackupQueryRateLimiter.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/PerSessionBackupQueryRateLimiter.kt
@@ -20,10 +20,9 @@ import dagger.Lazy
 import kotlinx.coroutines.withContext
 import org.matrix.android.sdk.api.MatrixCoroutineDispatchers
 import org.matrix.android.sdk.api.logger.LoggerTag
+import org.matrix.android.sdk.api.session.crypto.keysbackup.BackupRecoveryKey
 import org.matrix.android.sdk.api.session.crypto.keysbackup.KeysVersionResult
 import org.matrix.android.sdk.api.session.crypto.keysbackup.SavedKeyBackupKeyInfo
-import org.matrix.android.sdk.api.session.crypto.model.ImportRoomKeysResult
-import org.matrix.android.sdk.api.util.awaitCallback
 import org.matrix.android.sdk.internal.crypto.keysbackup.RustKeyBackupService
 import org.matrix.android.sdk.internal.crypto.store.IMXCryptoStore
 import org.matrix.android.sdk.internal.util.time.Clock
@@ -101,12 +100,12 @@ internal class PerSessionBackupQueryRateLimiter @Inject constructor(
                         (now - lastTry.timestamp) > MIN_TRY_BACKUP_PERIOD_MILLIS
 
         if (!shouldQuery) return false
-
+        val recoveryKey = savedKeyBackupKeyInfo?.recoveryKey ?: return false
         val successfullyImported = withContext(coroutineDispatchers.io) {
             try {
                     keysBackupService.get().restoreKeysWithRecoveryKey(
                             currentVersion,
-                            savedKeyBackupKeyInfo?.recoveryKey ?: "",
+                            recoveryKey,
                             roomId,
                             sessionId,
                             null,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/network/OutgoingRequestsProcessor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/network/OutgoingRequestsProcessor.kt
@@ -34,10 +34,10 @@ import uniffi.olm.RequestType
 
 private val loggerTag = LoggerTag("OutgoingRequestsProcessor", LoggerTag.CRYPTO)
 
-internal class NetworkRequestsProcessor(private val requestSender: RequestSender,
-                                        private val coroutineScope: CoroutineScope,
-                                        private val cryptoSessionInfoProvider: CryptoSessionInfoProvider,
-                                        private val shieldComputer: ShieldComputer,) {
+internal class OutgoingRequestsProcessor(private val requestSender: RequestSender,
+                                         private val coroutineScope: CoroutineScope,
+                                         private val cryptoSessionInfoProvider: CryptoSessionInfoProvider,
+                                         private val shieldComputer: ShieldComputer,) {
 
     fun interface ShieldComputer {
         suspend fun compute(userIds: List<String>): RoomEncryptionTrustLevel

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
@@ -35,6 +35,7 @@ import org.matrix.android.sdk.api.session.crypto.OutgoingRoomKeyRequestState
 import org.matrix.android.sdk.api.session.crypto.crosssigning.CryptoCrossSigningKey
 import org.matrix.android.sdk.api.session.crypto.crosssigning.MXCrossSigningInfo
 import org.matrix.android.sdk.api.session.crypto.crosssigning.PrivateKeysInfo
+import org.matrix.android.sdk.api.session.crypto.keysbackup.BackupRecoveryKey
 import org.matrix.android.sdk.api.session.crypto.keysbackup.SavedKeyBackupKeyInfo
 import org.matrix.android.sdk.api.session.crypto.model.AuditTrail
 import org.matrix.android.sdk.api.session.crypto.model.CryptoDeviceInfo
@@ -469,7 +470,8 @@ internal class RealmCryptoStore @Inject constructor(
                         val key = it.keyBackupRecoveryKey
                         val version = it.keyBackupRecoveryKeyVersion
                         if (!key.isNullOrBlank() && !version.isNullOrBlank()) {
-                            SavedKeyBackupKeyInfo(recoveryKey = key, version = version)
+                            val backupRecoveryKey = BackupRecoveryKey.fromBase58(key)
+                            SavedKeyBackupKeyInfo(recoveryKey = backupRecoveryKey, version = version)
                         } else {
                             null
                         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/room/RoomSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/room/RoomSyncHandler.kt
@@ -520,10 +520,9 @@ internal class RoomSyncHandler @Inject constructor(
 
     private fun decryptIfNeeded(event: Event, roomId: String) {
         try {
-            // Event from sync does not have roomId, so add it to the event first
             // note: runBlocking should be used here while we are in realm single thread executor, to avoid thread switching
             val result = runBlocking {
-                cryptoService.decryptEvent(event.copy(roomId = roomId), "")
+                cryptoService.decryptEvent(event, "")
             }
             event.mxDecryptionResult = OlmDecryptionResult(
                     payload = result.clearEvent,

--- a/vector/src/main/java/im/vector/app/features/crypto/keysbackup/restore/KeysBackupRestoreFromKeyViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/keysbackup/restore/KeysBackupRestoreFromKeyViewModel.kt
@@ -23,6 +23,7 @@ import im.vector.app.core.platform.WaitingViewData
 import im.vector.app.core.resources.StringProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.matrix.android.sdk.api.session.crypto.keysbackup.BackupRecoveryKey
 import javax.inject.Inject
 
 class KeysBackupRestoreFromKeyViewModel @Inject constructor(
@@ -42,7 +43,7 @@ class KeysBackupRestoreFromKeyViewModel @Inject constructor(
         sharedViewModel.loadingEvent.postValue(WaitingViewData(stringProvider.getString(R.string.loading)))
         recoveryCodeErrorText.value = null
         viewModelScope.launch(Dispatchers.IO) {
-            val recoveryKey = recoveryCode.value!!
+            val recoveryKey = BackupRecoveryKey.fromBase58(recoveryCode.value!!)
             try {
                 sharedViewModel.recoverUsingBackupRecoveryKey(recoveryKey)
             } catch (failure: Throwable) {

--- a/vector/src/main/java/im/vector/app/features/crypto/keysbackup/setup/KeysBackupSetupSharedViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/keysbackup/setup/KeysBackupSetupSharedViewModel.kt
@@ -27,6 +27,7 @@ import im.vector.app.core.time.Clock
 import im.vector.app.core.utils.LiveEvent
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.session.Session
+import org.matrix.android.sdk.api.session.crypto.keysbackup.BackupRecoveryKey
 import org.matrix.android.sdk.api.session.crypto.keysbackup.KeysBackupService
 import org.matrix.android.sdk.api.session.crypto.keysbackup.KeysVersion
 import org.matrix.android.sdk.api.session.crypto.keysbackup.MegolmBackupCreationInfo
@@ -71,7 +72,7 @@ class KeysBackupSetupSharedViewModel @Inject constructor(
     // Step 3
     // Var to ignore events from previous request(s) to generate a recovery key
     private var currentRequestId: MutableLiveData<Long> = MutableLiveData()
-    var recoveryKey: MutableLiveData<String?> = MutableLiveData(null)
+    var recoveryKey: MutableLiveData<BackupRecoveryKey?> = MutableLiveData(null)
     var prepareRecoverFailError: MutableLiveData<Throwable?> = MutableLiveData(null)
     var megolmBackupCreationInfo: MegolmBackupCreationInfo? = null
     var copyHasBeenMade = false

--- a/vector/src/main/java/im/vector/app/features/crypto/keysbackup/setup/KeysBackupSetupStep3Fragment.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/keysbackup/setup/KeysBackupSetupStep3Fragment.kt
@@ -66,7 +66,7 @@ class KeysBackupSetupStep3Fragment @Inject constructor() : VectorBaseFragment<Fr
                 views.keysBackupSetupStep3Label2.text = getString(R.string.keys_backup_setup_step3_text_line2_no_passphrase)
                 views.keysBackupSetupStep3FinishButton.text = getString(R.string.keys_backup_setup_step3_button_title_no_passphrase)
 
-                views.keysBackupSetupStep3RecoveryKeyText.text = viewModel.recoveryKey.value!!
+                views.keysBackupSetupStep3RecoveryKeyText.text = viewModel.recoveryKey.value!!.toBase58()
                         .replace(" ", "")
                         .chunked(16)
                         .joinToString("\n") {
@@ -114,7 +114,8 @@ class KeysBackupSetupStep3Fragment @Inject constructor() : VectorBaseFragment<Fr
         } else {
             dialog.findViewById<TextView>(R.id.keys_backup_recovery_key_text)?.let {
                 it.isVisible = true
-                it.text = recoveryKey.replace(" ", "")
+                it.text = recoveryKey.toBase58()
+                        .replace(" ", "")
                         .chunked(16)
                         .joinToString("\n") {
                             it
@@ -123,7 +124,7 @@ class KeysBackupSetupStep3Fragment @Inject constructor() : VectorBaseFragment<Fr
                         }
 
                 it.debouncedClicks {
-                    copyToClipboard(requireActivity(), recoveryKey)
+                    copyToClipboard(requireActivity(), recoveryKey.toBase58())
                 }
             }
         }
@@ -145,7 +146,7 @@ class KeysBackupSetupStep3Fragment @Inject constructor() : VectorBaseFragment<Fr
                     fragment = this,
                     activityResultLauncher = null,
                     chooserTitle = context?.getString(R.string.keys_backup_setup_step3_share_intent_chooser_title),
-                    text = recoveryKey,
+                    text = recoveryKey.toBase58(),
                     subject = context?.getString(R.string.recovery_key)
             )
             viewModel.copyHasBeenMade = true
@@ -159,7 +160,7 @@ class KeysBackupSetupStep3Fragment @Inject constructor() : VectorBaseFragment<Fr
         viewModel.recoveryKey.value?.let {
             viewModel.copyHasBeenMade = true
 
-            copyToClipboard(requireActivity(), it)
+            copyToClipboard(requireActivity(), it.toBase58())
         }
     }
 
@@ -202,7 +203,7 @@ class KeysBackupSetupStep3Fragment @Inject constructor() : VectorBaseFragment<Fr
         val uri = activityRessult.data?.data ?: return@registerStartForActivityResult
         if (activityRessult.resultCode == Activity.RESULT_OK) {
             viewModel.recoveryKey.value?.let {
-                exportRecoveryKeyToFile(uri, it)
+                exportRecoveryKeyToFile(uri, it.toBase58())
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/crypto/recover/BackupToQuadSMigrationTask.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/recover/BackupToQuadSMigrationTask.kt
@@ -23,6 +23,7 @@ import im.vector.app.core.resources.StringProvider
 import org.matrix.android.sdk.api.listeners.ProgressListener
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.crypto.crosssigning.KEYBACKUP_SECRET_SSSS_NAME
+import org.matrix.android.sdk.api.session.crypto.keysbackup.BackupRecoveryKey
 import org.matrix.android.sdk.api.session.crypto.keysbackup.computeRecoveryKey
 import org.matrix.android.sdk.api.session.crypto.keysbackup.extractCurveKeyFromRecoveryKey
 import org.matrix.android.sdk.api.session.securestorage.EmptyKeySigner
@@ -91,8 +92,8 @@ class BackupToQuadSMigrationTask @Inject constructor(
 
             reportProgress(params, R.string.bootstrap_progress_compute_curve_key)
             val recoveryKey = computeRecoveryKey(curveKey)
-
-            val isValid = keysBackupService.isValidRecoveryKeyForCurrentVersion(recoveryKey)
+            val backupRecoveryKey = BackupRecoveryKey.fromBase58(recoveryKey)
+            val isValid = keysBackupService.isValidRecoveryKeyForCurrentVersion(backupRecoveryKey)
 
             if (!isValid) return Result.InvalidRecoverySecret
 
@@ -143,7 +144,7 @@ class BackupToQuadSMigrationTask @Inject constructor(
             )
 
             // save for gossiping
-            keysBackupService.saveBackupRecoveryKey(recoveryKey, version.version)
+            keysBackupService.saveBackupRecoveryKey(backupRecoveryKey, version.version)
             // It's not a good idea to download the full backup, it might take very long
             // and use a lot of resources
             return Result.Success

--- a/vector/src/main/java/im/vector/app/features/crypto/recover/BootstrapCrossSigningTask.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/recover/BootstrapCrossSigningTask.kt
@@ -236,7 +236,7 @@ class BootstrapCrossSigningTask @Inject constructor(
                 Timber.d("## BootstrapCrossSigningTask: Creating 4S - Save megolm backup key for gossiping")
                 session.cryptoService().keysBackupService().saveBackupRecoveryKey(creationInfo.recoveryKey, version = version.version)
 
-                extractCurveKeyFromRecoveryKey(creationInfo.recoveryKey)?.toBase64NoPadding()?.let { secret ->
+                extractCurveKeyFromRecoveryKey(creationInfo.recoveryKey.toBase58())?.toBase64NoPadding()?.let { secret ->
                     ssssService.storeSecret(
                             KEYBACKUP_SECRET_SSSS_NAME,
                             secret,
@@ -251,7 +251,7 @@ class BootstrapCrossSigningTask @Inject constructor(
                     val isValid = session.cryptoService().keysBackupService().isValidRecoveryKeyForCurrentVersion(knownMegolmSecret!!.recoveryKey)
                     if (isValid) {
                         Timber.d("## BootstrapCrossSigningTask: Creating 4S - Megolm key valid and known")
-                        extractCurveKeyFromRecoveryKey(knownMegolmSecret.recoveryKey)?.toBase64NoPadding()?.let { secret ->
+                        extractCurveKeyFromRecoveryKey(knownMegolmSecret.recoveryKey.toBase58())?.toBase64NoPadding()?.let { secret ->
                             ssssService.storeSecret(
                                     KEYBACKUP_SECRET_SSSS_NAME,
                                     secret,


### PR DESCRIPTION
Introduce a BackupRecoveryKey wrapper class (to avoid directly expose uniffi generated classes)
Use this class instead of plain string in the BackupService methods.
Still pass string to rust ffi as it has not been updated yet (will be done in a next PR).
