### PR TITLE
Use backup key directly on olmMachine.

### DIFF
--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -140,7 +140,7 @@ dependencies {
     implementation libs.jetbrains.coroutinesCore
     implementation libs.jetbrains.coroutinesAndroid
 
-    implementation 'org.matrix.rustcomponents:crypto-android:0.1.0'
+    implementation 'org.matrix.rustcomponents:crypto-android:0.2.1-SNAPSHOT'
     //implementation files('libs/crypto-android-release.aar')
 
 //    implementation(name: 'crypto-android-release', ext: 'aar')

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OlmMachine.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OlmMachine.kt
@@ -58,6 +58,7 @@ import org.matrix.android.sdk.internal.network.parsing.CheckNumberType
 import org.matrix.android.sdk.internal.util.time.Clock
 import timber.log.Timber
 import uniffi.olm.BackupKeys
+import uniffi.olm.BackupRecoveryKey
 import uniffi.olm.CrossSigningKeyExport
 import uniffi.olm.CrossSigningStatus
 import uniffi.olm.CryptoStoreException
@@ -840,7 +841,7 @@ internal class OlmMachine(
     }
 
     @Throws(CryptoStoreException::class)
-    suspend fun saveRecoveryKey(key: String?, version: String?) {
+    suspend fun saveRecoveryKey(key: BackupRecoveryKey?, version: String?) {
         withContext(coroutineDispatchers.computation) {
             inner.saveRecoveryKey(key, version)
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/keysbackup/RustKeyBackupService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/keysbackup/RustKeyBackupService.kt
@@ -191,9 +191,7 @@ internal class RustKeyBackupService @Inject constructor(
 
     override fun saveBackupRecoveryKey(recoveryKey: BackupRecoveryKey?, version: String?) {
         cryptoCoroutineScope.launch {
-            val recoveryKeyStr = recoveryKey?.toBase64()
-            // TODO : change rust API to use BackupRecoveryKey
-            olmMachine.saveRecoveryKey(recoveryKeyStr, version)
+            olmMachine.saveRecoveryKey(recoveryKey?.inner, version)
         }
     }
 
@@ -729,9 +727,8 @@ internal class RustKeyBackupService @Inject constructor(
 
     override suspend fun getKeyBackupRecoveryKeyInfo(): SavedKeyBackupKeyInfo? {
         val info = olmMachine.getBackupKeys() ?: return null
-        // TODO change rust ffi to return BackupRecoveryKey instead of base64 string
-        val backupRecoveryKey = BackupRecoveryKey.fromBase64(info.recoveryKey)
-        return SavedKeyBackupKeyInfo(backupRecoveryKey, info.backupVersion)
+        val backupRecoveryKey = BackupRecoveryKey(info.recoveryKey())
+        return SavedKeyBackupKeyInfo(backupRecoveryKey, info.backupVersion())
     }
 
     /**


### PR DESCRIPTION
Finish the work to use BackupRecoveryKey directly on olmMachine instead of string (related to https://github.com/matrix-org/matrix-rust-sdk/pull/719)