### PR TITLE
Fga/feature/handle request failing

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/Device.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/Device.kt
@@ -114,7 +114,7 @@ internal class Device @AssistedInject constructor(
             try {
                 requestSender.sendVerificationRequest(result.request)
                 sasVerificationFactory.create(result.sas)
-            }catch (failure: Throwable){
+            } catch (failure: Throwable) {
                 innerMachine.cancelVerification(result.sas.otherUserId, result.sas.flowId, CancelCode.UserError.value)
                 null
             }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/SecretShareManager.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/SecretShareManager.kt
@@ -241,7 +241,7 @@ internal class SecretShareManager @Inject constructor(
         )
         try {
             withContext(coroutineDispatchers.io) {
-                sendToDeviceTask.executeRetry(params, 3)
+                sendToDeviceTask.execute(params)
             }
             Timber.tag(loggerTag.value)
                     .d("Secret request sent for $secretName to ${cryptoDeviceInfo.shortDebugString()}")

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/keysbackup/tasks/GetKeysBackupLastVersionTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/keysbackup/tasks/GetKeysBackupLastVersionTask.kt
@@ -33,7 +33,7 @@ internal class DefaultGetKeysBackupLastVersionTask @Inject constructor(
 
     override suspend fun execute(params: Unit): KeysBackupLastVersionResult {
         return try {
-            val keysVersionResult = executeRequest(globalErrorReceiver) {
+            val keysVersionResult = executeRequest(globalErrorReceiver, canRetry = true) {
                 roomKeysApi.getKeysBackupLastVersion()
             }
             KeysBackupLastVersionResult.KeysBackup(keysVersionResult)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/keysbackup/tasks/GetKeysBackupVersionTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/keysbackup/tasks/GetKeysBackupVersionTask.kt
@@ -31,7 +31,7 @@ internal class DefaultGetKeysBackupVersionTask @Inject constructor(
 ) : GetKeysBackupVersionTask {
 
     override suspend fun execute(params: String): KeysVersionResult {
-        return executeRequest(globalErrorReceiver) {
+        return executeRequest(globalErrorReceiver, canRetry = true) {
             roomKeysApi.getKeysBackupVersion(params)
         }
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/keysbackup/tasks/StoreSessionsDataTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/keysbackup/tasks/StoreSessionsDataTask.kt
@@ -37,7 +37,7 @@ internal class DefaultStoreSessionsDataTask @Inject constructor(
 ) : StoreSessionsDataTask {
 
     override suspend fun execute(params: StoreSessionsDataTask.Params): BackupKeysResult {
-        return executeRequest(globalErrorReceiver) {
+        return executeRequest(globalErrorReceiver, canRetry = true) {
             roomKeysApi.storeSessionsData(
                     params.version,
                     params.keysBackupData

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/keysbackup/tasks/UpdateKeysBackupVersionTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/keysbackup/tasks/UpdateKeysBackupVersionTask.kt
@@ -36,7 +36,7 @@ internal class DefaultUpdateKeysBackupVersionTask @Inject constructor(
 ) : UpdateKeysBackupVersionTask {
 
     override suspend fun execute(params: UpdateKeysBackupVersionTask.Params) {
-        return executeRequest(globalErrorReceiver) {
+        return executeRequest(globalErrorReceiver, canRetry = true) {
             roomKeysApi.updateKeysBackupVersion(params.version, params.keysBackupVersionBody)
         }
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/network/RequestSender.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/network/RequestSender.kt
@@ -132,7 +132,12 @@ internal class RequestSender @Inject constructor(
         return responseAdapter.toJson(sendResponse)
     }
 
-    suspend fun sendRoomMessage(eventType: String, roomId: String, content: String, transactionId: String, retryCount: Int = DEFAULT_REQUEST_RETRY_COUNT): SendResponse {
+    suspend fun sendRoomMessage(eventType: String,
+                                roomId: String,
+                                content: String,
+                                transactionId: String,
+                                retryCount: Int = DEFAULT_REQUEST_RETRY_COUNT
+    ): SendResponse {
         val paramsAdapter = moshi.adapter<Content>(Map::class.java)
         val jsonContent = paramsAdapter.fromJson(content)
         val event = Event(eventType, transactionId, jsonContent, roomId = roomId)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/ClaimOneTimeKeysForUsersDeviceTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/ClaimOneTimeKeysForUsersDeviceTask.kt
@@ -39,7 +39,7 @@ internal class DefaultClaimOneTimeKeysForUsersDevice @Inject constructor(
     override suspend fun execute(params: ClaimOneTimeKeysForUsersDeviceTask.Params): KeysClaimResponse {
         val body = KeysClaimBody(oneTimeKeys = params.usersDevicesKeyTypesMap)
 
-        return executeRequest(globalErrorReceiver) {
+        return executeRequest(globalErrorReceiver, canRetry = true) {
             cryptoApi.claimOneTimeKeysForUsersDevices(body)
         }
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/DownloadKeysForUsersTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/DownloadKeysForUsersTask.kt
@@ -97,7 +97,7 @@ internal class DefaultDownloadKeysForUsers @Inject constructor(
             )
         } else {
             // No need to chunk, direct request
-            executeRequest(globalErrorReceiver) {
+            executeRequest(globalErrorReceiver, canRetry = true) {
                 cryptoApi.downloadKeysForUsers(
                         KeysQueryBody(
                                 deviceKeys = params.userIds.associateWith { emptyList() },

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/SendToDeviceTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/SendToDeviceTask.kt
@@ -35,7 +35,7 @@ internal interface SendToDeviceTask : Task<SendToDeviceTask.Params, Unit> {
             // the transactionId. If not provided, a transactionId will be created by the task
             val transactionId: String? = null,
             // Number of retry before failing
-            val retryCount:Int = DEFAULT_REQUEST_RETRY_COUNT
+            val retryCount: Int = DEFAULT_REQUEST_RETRY_COUNT
     )
 }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/SendToDeviceTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/SendToDeviceTask.kt
@@ -19,6 +19,7 @@ package org.matrix.android.sdk.internal.crypto.tasks
 import org.matrix.android.sdk.api.session.crypto.model.MXUsersDevicesMap
 import org.matrix.android.sdk.internal.crypto.api.CryptoApi
 import org.matrix.android.sdk.internal.crypto.model.rest.SendToDeviceBody
+import org.matrix.android.sdk.internal.network.DEFAULT_REQUEST_RETRY_COUNT
 import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.task.Task
@@ -32,7 +33,9 @@ internal interface SendToDeviceTask : Task<SendToDeviceTask.Params, Unit> {
             // the content to send. Map from user_id to device_id to content dictionary.
             val contentMap: MXUsersDevicesMap<Any>,
             // the transactionId. If not provided, a transactionId will be created by the task
-            val transactionId: String? = null
+            val transactionId: String? = null,
+            // Number of retry before failing
+            val retryCount:Int = DEFAULT_REQUEST_RETRY_COUNT
     )
 }
 
@@ -54,7 +57,7 @@ internal class DefaultSendToDeviceTask @Inject constructor(
         return executeRequest(
                 globalErrorReceiver,
                 canRetry = true,
-                maxRetriesCount = 3
+                maxRetriesCount = params.retryCount
         ) {
             cryptoApi.sendToDevice(
                     eventType = params.eventType,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/UploadKeysTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/UploadKeysTask.kt
@@ -38,7 +38,7 @@ internal class DefaultUploadKeysTask @Inject constructor(
 
     override suspend fun execute(params: UploadKeysTask.Params): KeysUploadResponse {
         Timber.i("## Uploading device keys -> $params.body")
-        return executeRequest(globalErrorReceiver) {
+        return executeRequest(globalErrorReceiver, canRetry = true) {
             cryptoApi.uploadKeys(params.body)
         }
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/UploadSigningKeysTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/UploadSigningKeysTask.kt
@@ -60,7 +60,7 @@ internal class DefaultUploadSigningKeysTask @Inject constructor(
     }
 
     private suspend fun doRequest(uploadQuery: UploadSigningKeysBody) {
-        val keysQueryResponse = executeRequest(globalErrorReceiver) {
+        val keysQueryResponse = executeRequest(globalErrorReceiver, canRetry = true) {
             cryptoApi.uploadSigningKeys(uploadQuery)
         }
         if (keysQueryResponse.failures?.isNotEmpty() == true) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/Request.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/Request.kt
@@ -39,10 +39,13 @@ import java.io.IOException
  * @param maxRetriesCount the max number of retries
  * @param requestBlock a suspend lambda to perform the network request
  */
+
+internal const val DEFAULT_REQUEST_RETRY_COUNT = 4
+
 internal suspend inline fun <DATA> executeRequest(globalErrorReceiver: GlobalErrorReceiver?,
                                                   canRetry: Boolean = false,
                                                   maxDelayBeforeRetry: Long = 32_000L,
-                                                  maxRetriesCount: Int = 4,
+                                                  maxRetriesCount: Int = DEFAULT_REQUEST_RETRY_COUNT,
                                                   noinline requestBlock: suspend () -> DATA): DATA {
     var currentRetryCount = 0
     var currentDelay = 1_000L

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultToDeviceService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultToDeviceService.kt
@@ -37,13 +37,12 @@ internal class DefaultToDeviceService @Inject constructor(
     }
 
     override suspend fun sendToDevice(eventType: String, contentMap: MXUsersDevicesMap<Any>, txnId: String?) {
-        sendToDeviceTask.executeRetry(
+        sendToDeviceTask.execute(
                 SendToDeviceTask.Params(
                         eventType = eventType,
                         contentMap = contentMap,
                         transactionId = txnId
-                ),
-                3
+                )
         )
     }
 


### PR DESCRIPTION
Use retry mechanism from `executeRequest` instead of `executeRetry` from `Task` for `RequestSender`
Cancel the flow (with infinite retry) if requests are throwing.